### PR TITLE
Remove deprecated class-property eslint plugin from config

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ module.exports = {
     plugins: [
         'react',
         'brackets',
-        'class-property',
     ],
     globals: {
         'jest': false,
@@ -54,7 +53,6 @@ module.exports = {
         }],
         'semi': ['error', 'never'],
         'no-extra-semi': 'error',
-        'class-property/class-property-semicolon': ['error', 'never'],
         'no-unexpected-multiline': 'error',
         'new-cap': 'off',
         'prefer-template': 'off',

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint-plugin-flowtype": "^2.40.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
-    "eslint-plugin-react": "^7.5.1",
-    "eslint-plugin-class-property": "^1.0.6"
+    "eslint-plugin-react": "^7.5.1"
   }
 }


### PR DESCRIPTION
This removes the class-property plugin from the configuration. It's [been deprecated](https://www.npmjs.com/package/eslint-plugin-class-property), anyway.

The plugin forces installation of `eslint@3.19.0`, but `react-scripts@2.1.5` requires `eslint@5.12.0`, so it causes an error on preflight dependency checks in the teamcity.

I'll be releasing the change into a new version; it shouldn't affect any of our projects negatively since they should be locked to the previous version (1.4.2). If the eslint gets upgraded and the missing plugin causes issues, we can deal with it then.

I tested with my `package.json` target against a local fork with these changes, so i think we should be good to go.